### PR TITLE
Pre-process i18n templates

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -25,10 +25,14 @@ module.exports = function (data, options) {
       templates.forEach(function (page) {
         var ext = path.extname(page);
         var pageObj = matter.read(page);
+        var i18nContext;
 
         i18n = _.extend({}, i18n, {languages: languages});
+        i18nContext = {language: language, i18n: i18n};
 
-        var context = _.extend({}, data, {language: language, i18n: i18n}, pageObj.context);
+        pageObj.context = JSON.parse(_.template(JSON.stringify(pageObj.context))(i18nContext));
+
+        var context = _.extend({}, data, i18nContext, pageObj.context);
         var filename = page.replace(ext, "-" + language + ext);
 
         pages[filename] = {


### PR DESCRIPTION
i18n doesn't work with autogenerated menus because front-matter is process right before the page is rendered, meaning that a partial only has access to i18n parameter of pages that were previously rendered