### PR TITLE
Setting default language to avoid <file>-<lang>.ext files for this language

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = function (params, callback) {
     var data = params.assemble.options.data;
     var templates = opts.templates;
     var languages = opts.languages;
+    var defaultLanguage = opts.defaultLanguage;
 
     if (opts.data) {
        o.data = opts.data;
@@ -49,6 +50,10 @@ module.exports = function (params, callback) {
 
     if (languages) {
       o.languages = languages;
+    }
+
+    if (defaultLanguage) {
+      o.defaultLanguage = defaultLanguage;
     }
 
     var pages = i18n(data, o);

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -11,6 +11,8 @@ module.exports = function (data, options) {
 
   var languages = options.languages || [];
 
+  var defaultLanguage = options.defaultLanguage || '';
+
   var process = function () {
     var i18n = [];
 
@@ -29,7 +31,7 @@ module.exports = function (data, options) {
         i18n = _.extend({}, i18n, {languages: languages});
 
         var context = _.extend({}, data, {language: language, i18n: i18n}, pageObj.context);
-        var filename = page.replace(ext, "-" + language + ext);
+        var filename = defaultLanguage !== language ? page.replace(ext, "-" + language + ext) : page;
 
         pages[filename] = {
           filename: filename,


### PR DESCRIPTION
Setting a "defaultLanguage" will create files for this language as simple <filename>.ext files, instead of <filename>-<language>.ext.